### PR TITLE
Column Order is random when running on Python 2

### DIFF
--- a/openpyxl_templates/table_sheet/columns.py
+++ b/openpyxl_templates/table_sheet/columns.py
@@ -37,6 +37,7 @@ class BlankNotAllowed(CellException):
 class TableColumn(object):
     _object_attribute = Typed("_object_attribute", expected_type=str, allow_none=True)
     source = Typed("source", expected_types=(str, FunctionType), allow_none=True)
+    creation_counter = 0
     _column_index = None
 
     # Rendering properties
@@ -85,6 +86,8 @@ class TableColumn(object):
         self.row_style = row_style
 
         self.freeze = freeze
+        self.column_index = TableColumn.creation_counter
+        TableColumn.creation_counter+=1
 
     def get_value_from_object(self, obj):
         if isinstance(obj, (list, tuple)):

--- a/openpyxl_templates/utils.py
+++ b/openpyxl_templates/utils.py
@@ -1,3 +1,4 @@
+import inspect
 from collections import OrderedDict
 from weakref import WeakKeyDictionary
 
@@ -127,17 +128,13 @@ class OrderedType(type):
             columns = sorted(inspect.getmembers(cls, lambda o: isinstance(o, TableColumn)),
                                  key=lambda i: i[1].column_index)
             if columns:
-                from openpyxl_templates.table_sheet.columns import TableColumn
-                cls = type.__new__(mcs, name, bases, classdict)
-                columns = sorted(inspect.getmembers(cls, lambda o: isinstance(o, TableColumn)),
-                                 key=lambda i: i[1].column_index)
                 for column in columns:
                     if issubclass(type(column[1]), item_class):
                         items[column[0]] = column[1]
             else:
-            for key, value in classdict.items():
-                if issubclass(type(value), item_class):
-                    items[key] = value
+                for key, value in classdict.items():
+                    if issubclass(type(value), item_class):
+                        items[key] = value
 
         obj._items = items
 

--- a/openpyxl_templates/utils.py
+++ b/openpyxl_templates/utils.py
@@ -122,6 +122,19 @@ class OrderedType(type):
 
         item_class = getattr(obj, "item_class", None)
         if item_class:
+            from openpyxl_templates.table_sheet.columns import TableColumn
+            cls = type.__new__(mcs, name, bases, classdict)
+            columns = sorted(inspect.getmembers(cls, lambda o: isinstance(o, TableColumn)),
+                                 key=lambda i: i[1].column_index)
+            if columns:
+                from openpyxl_templates.table_sheet.columns import TableColumn
+                cls = type.__new__(mcs, name, bases, classdict)
+                columns = sorted(inspect.getmembers(cls, lambda o: isinstance(o, TableColumn)),
+                                 key=lambda i: i[1].column_index)
+                for column in columns:
+                    if issubclass(type(column[1]), item_class):
+                        items[column[0]] = column[1]
+            else:
             for key, value in classdict.items():
                 if issubclass(type(value), item_class):
                     items[key] = value


### PR DESCRIPTION
There may be a better solution by retaining the column list and using it in the TableSheet init module.  Additionally this also doesn't address the sequence of tabs which is the same problem as columns.

This solution actually assigns the column_index when the column is initialized instead of waiting for it to be done in the TableSheet module.  I did not remove the initialization done in that module since it does not cause any issue since the items list in in the correct order.

Source of the issue is Python 2 does not retain order of the metaclass attributes which Python 3.4+ addressed in those versions.